### PR TITLE
Render `spec.channel` in `ClusterVersion` from parameter `openshiftVersion`

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -4,5 +4,4 @@ parameters:
       Major: "4"
       Minor: "8"
     spec:
-      channel: stable-4.8
       upstream: https://api.openshift.com/api/upgrades_info/v1/graph

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -15,6 +15,7 @@ local clusterVersion = kube._Object('config.openshift.io/v1', 'ClusterVersion', 
     [if cluster_gt_411 then 'capabilities']: {
       baselineCapabilitySet: 'v4.11',
     },
+    channel: 'stable-%(Major)s.%(Minor)s' % params.openshiftVersion,
   } + com.makeMergeable(params.spec),
 };
 

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -15,7 +15,12 @@ Minor: '8'
 ----
 
 This parameter is used to conditionally add configurations in the `ClusterVersion` object.
-The component currently uses this parameter to set the default value for field `capabilities.baselineCapabilitySet`, which was introduced in OpenShift 4.11, to `v4.11`.
+
+The component currently uses this parameter to set default values for
+* field `capabilities.baselineCapabilitySet`, which was introduced in OpenShift 4.11.
+The component defaults this field to `v4.11`.
+* field `channel`.
+The component sets this field to `stable-<Major>.<Minor>`, where `<Major>` and `<Minor>` are replaced with the values of fields `Major` and `Minor` of this parameter.
 
 == `spec`
 
@@ -27,7 +32,6 @@ default::
 +
 [source,yaml]
 ----
-channel: stable-4.8
 upstream: https://api.openshift.com/api/upgrades_info/v1/graph
 ----
 

--- a/tests/golden/openshift-4.11/openshift4-version/openshift4-version/version.yaml
+++ b/tests/golden/openshift-4.11/openshift4-version/openshift4-version/version.yaml
@@ -8,5 +8,5 @@ metadata:
 spec:
   capabilities:
     baselineCapabilitySet: v4.11
-  channel: stable-4.8
+  channel: stable-4.11
   upstream: https://api.openshift.com/api/upgrades_info/v1/graph


### PR DESCRIPTION
Change the component to render `spec.channel` in the ClusterVersion object as `stable-<Major>.<Minor>` from parameter `openshiftVersion` by default.

Channel values provided in parameter `spec` take precedence over the default value.

Follow-up to #22 

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
