### PR TITLE
Allow `openshift-upgrade-controller` to manage the `ClusterVersion`

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,13 +1,13 @@
 {
   "template": "https://github.com/projectsyn/commodore-component-template.git",
-  "commit": "956a1b342ed680b02b1fb1b646dc5d4c640e2028",
+  "commit": "880649ead47cceac7eaffd954f836e1428160fca",
   "checkout": "main",
   "context": {
     "cookiecutter": {
       "name": "OpenShift 4 Version",
       "slug": "openshift4-version",
       "parameter_key": "openshift4_version",
-      "test_cases": "defaults openshift-4.11",
+      "test_cases": "defaults openshift-4.11 upgrade-controller",
       "add_lib": "n",
       "add_pp": "n",
       "add_golden": "y",

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,6 +34,7 @@ jobs:
         instance:
           - defaults
           - openshift-4.11
+          - upgrade-controller
     defaults:
       run:
         working-directory: ${{ env.COMPONENT_NAME }}
@@ -50,6 +51,7 @@ jobs:
         instance:
           - defaults
           - openshift-4.11
+          - upgrade-controller
     defaults:
       run:
         working-directory: ${{ env.COMPONENT_NAME }}

--- a/Makefile.vars.mk
+++ b/Makefile.vars.mk
@@ -56,4 +56,4 @@ KUBENT_IMAGE    ?= ghcr.io/doitintl/kube-no-trouble:latest
 KUBENT_DOCKER   ?= $(DOCKER_CMD) $(DOCKER_ARGS) $(root_volume) --entrypoint=/app/kubent $(KUBENT_IMAGE)
 
 instance ?= defaults
-test_instances = tests/defaults.yml tests/openshift-4.11.yml
+test_instances = tests/defaults.yml tests/openshift-4.11.yml tests/upgrade-controller.yml

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -5,3 +5,9 @@ parameters:
       Minor: "8"
     spec:
       upstream: https://api.openshift.com/api/upgrades_info/v1/graph
+
+    images:
+      kubectl:
+        registry: docker.io
+        image: bitnami/kubectl
+        tag: '1.25.5@sha256:d4a21c081ec10396029758e340ec9ba09bc9dbc9066bb0f55f1cba56ab1cf598'

--- a/class/openshift4-version.yml
+++ b/class/openshift4-version.yml
@@ -7,5 +7,6 @@ parameters:
         output_path: apps/
       - input_paths:
           - openshift4-version/component/main.jsonnet
+          - openshift4-version/component/make_unmanaged.jsonnet
         input_type: jsonnet
         output_path: openshift4-version/

--- a/component/common.libsonnet
+++ b/component/common.libsonnet
@@ -1,0 +1,9 @@
+local kap = import 'lib/kapitan.libjsonnet';
+local inv = kap.inventory();
+local params = inv.parameters.openshift4_version;
+
+local upgradeControllerEnabled = std.member(inv.applications, 'openshift-upgrade-controller');
+
+{
+  UpgradeControllerEnabled: upgradeControllerEnabled,
+}

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -3,7 +3,9 @@ local com = import 'lib/commodore.libjsonnet';
 local kap = import 'lib/kapitan.libjsonnet';
 local kube = import 'lib/kube.libjsonnet';
 local inv = kap.inventory();
+local common = import 'common.libsonnet';
 // The hiera parameters for the component
+
 local params = inv.parameters.openshift4_version;
 
 local cluster_gt_411 =
@@ -11,6 +13,11 @@ local cluster_gt_411 =
   std.parseInt(params.openshiftVersion.Minor) >= 11;
 
 local clusterVersion = kube._Object('config.openshift.io/v1', 'ClusterVersion', 'version') {
+  metadata+: {
+    annotations+: {
+      'argocd.argoproj.io/sync-options': 'Prune=false,Delete=false',
+    },
+  },
   spec: {
     [if cluster_gt_411 then 'capabilities']: {
       baselineCapabilitySet: 'v4.11',
@@ -21,5 +28,5 @@ local clusterVersion = kube._Object('config.openshift.io/v1', 'ClusterVersion', 
 
 // Define outputs below
 {
-  version: clusterVersion,
+  [if !common.UpgradeControllerEnabled then 'version']: clusterVersion,
 }

--- a/component/make_unmanaged.jsonnet
+++ b/component/make_unmanaged.jsonnet
@@ -1,0 +1,81 @@
+local kap = import 'lib/kapitan.libjsonnet';
+local kube = import 'lib/kube.libjsonnet';
+local inv = kap.inventory();
+local params = inv.parameters.openshift4_version;
+local common = import 'common.libsonnet';
+
+local name = 'clusterversion-make-unmanaged';
+local namespace = 'openshift-cluster-version';
+
+local addSyncWave = function(object) object {
+  metadata+: {
+    annotations+: {
+      'argocd.argoproj.io/sync-wave': '-10',
+    },
+  },
+};
+
+local script = importstr './make_unmanaged/patch-clusterversion.sh';
+
+local role = kube.ClusterRole(name) {
+  rules: [
+    {
+      apiGroups: [ 'config.openshift.io' ],
+      resources: [ 'clusterversions' ],
+      resourceNames: [ 'version' ],
+      verbs: [ 'get', 'patch', 'update' ],
+    },
+  ],
+};
+
+local serviceAccount = kube.ServiceAccount(name) {
+  metadata+: { namespace: namespace },
+};
+
+local roleBinding = kube.ClusterRoleBinding(name) {
+  subjects_: [ serviceAccount ],
+  roleRef_: role,
+};
+
+local job = kube.Job(name) {
+  metadata+: {
+    namespace: namespace,
+    annotations+: {
+      'argocd.argoproj.io/hook': 'Sync',
+      'argocd.argoproj.io/hook-delete-policy': 'HookSucceeded',
+    },
+  },
+  spec+: {
+    template+: {
+      spec+: {
+        serviceAccountName: serviceAccount.metadata.name,
+        containers_+: {
+          ensure: kube.Container(name) {
+            image: '%s/%s:%s' % [ params.images.kubectl.registry, params.images.kubectl.image, params.images.kubectl.tag ],
+            workingDir: '/export',
+            command: [ 'sh' ],
+            args: [ '-eu', '-c', script ],
+            env: [
+              { name: 'HOME', value: '/export' },
+            ],
+            volumeMounts: [
+              { name: 'export', mountPath: '/export' },
+            ],
+          },
+        },
+        volumes+: [
+          { name: 'export', emptyDir: {} },
+        ],
+      },
+    },
+  },
+};
+
+{
+  [if common.UpgradeControllerEnabled then '00_make_unmanaged']: [
+    addSyncWave(role),
+    addSyncWave(serviceAccount),
+    addSyncWave(roleBinding),
+    addSyncWave(job),
+  ],
+}

--- a/component/make_unmanaged/patch-clusterversion.sh
+++ b/component/make_unmanaged/patch-clusterversion.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -eu
+
+kubectl annotate --overwrite clusterversion version argocd.argoproj.io/sync-options='Prune=false,Delete=false'
+kubectl label clusterversion version argocd.argoproj.io/instance-

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -1,5 +1,12 @@
 = OpenShift 4 Version: A Commodore component to manage OpenShift 4 Version
 
+[IMPORTANT]
+====
+This component is deprecated and will be removed in the future.
+
+If `openshift-upgrade-controller` is found in the installed applications, the upgade controller will take over the control of the ClusterVersion object.
+====
+
 {doctitle} is a Commodore component for managing the OpenShift 4 cluster version.
 It takes over control of the ClusterVersion object named version.
 By this, the component allows to control which version the cluster is running.

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -24,8 +24,6 @@ The component sets this field to `stable-<Major>.<Minor>`, where `<Major>` and `
 
 == `spec`
 
-
-
 [horizontal]
 type:: object
 default::
@@ -46,6 +44,17 @@ We recommend that users set `spec.clusterID` to a non-component parameter such a
 ====
 
 Values specified in this parameter take precedence over default values derived from parameter `openshiftVersion`.
+
+
+== `images`
+[horizontal]
+type:: dict
+default:: See https://github.com/projectsyn/component-rook-ceph/blob/master/class/defaults.yml[`class/defaults.yml` on Github]
+
+This parameter allows selecting the Docker images to use for the job making the cluster version unmanaged.
+Each image is specified using keys `registry`, `image` and `tag`.
+This structure allows easily injecting a registry mirror, if required.
+
 
 == Example
 

--- a/tests/golden/defaults/openshift4-version/openshift4-version/version.yaml
+++ b/tests/golden/defaults/openshift4-version/openshift4-version/version.yaml
@@ -1,7 +1,8 @@
 apiVersion: config.openshift.io/v1
 kind: ClusterVersion
 metadata:
-  annotations: {}
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false,Delete=false
   labels:
     name: version
   name: version

--- a/tests/golden/openshift-4.11/openshift4-version/openshift4-version/version.yaml
+++ b/tests/golden/openshift-4.11/openshift4-version/openshift4-version/version.yaml
@@ -1,7 +1,8 @@
 apiVersion: config.openshift.io/v1
 kind: ClusterVersion
 metadata:
-  annotations: {}
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false,Delete=false
   labels:
     name: version
   name: version

--- a/tests/golden/upgrade-controller/openshift4-version/openshift4-version/00_make_unmanaged.yaml
+++ b/tests/golden/upgrade-controller/openshift4-version/openshift4-version/00_make_unmanaged.yaml
@@ -1,0 +1,99 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: '-10'
+  labels:
+    name: clusterversion-make-unmanaged
+  name: clusterversion-make-unmanaged
+rules:
+  - apiGroups:
+      - config.openshift.io
+    resourceNames:
+      - version
+    resources:
+      - clusterversions
+    verbs:
+      - get
+      - patch
+      - update
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: '-10'
+  labels:
+    name: clusterversion-make-unmanaged
+  name: clusterversion-make-unmanaged
+  namespace: openshift-cluster-version
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: '-10'
+  labels:
+    name: clusterversion-make-unmanaged
+  name: clusterversion-make-unmanaged
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: clusterversion-make-unmanaged
+subjects:
+  - kind: ServiceAccount
+    name: clusterversion-make-unmanaged
+    namespace: openshift-cluster-version
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+    argocd.argoproj.io/sync-wave: '-10'
+  labels:
+    name: clusterversion-make-unmanaged
+  name: clusterversion-make-unmanaged
+  namespace: openshift-cluster-version
+spec:
+  completions: 1
+  parallelism: 1
+  template:
+    metadata:
+      labels:
+        name: clusterversion-make-unmanaged
+    spec:
+      containers:
+        - args:
+            - -eu
+            - -c
+            - |
+              #!/bin/sh
+              set -eu
+
+              kubectl annotate --overwrite clusterversion version argocd.argoproj.io/sync-options='Prune=false,Delete=false'
+              kubectl label clusterversion version argocd.argoproj.io/instance-
+          command:
+            - sh
+          env:
+            - name: HOME
+              value: /export
+          image: docker.io/bitnami/kubectl:1.25.5@sha256:d4a21c081ec10396029758e340ec9ba09bc9dbc9066bb0f55f1cba56ab1cf598
+          imagePullPolicy: IfNotPresent
+          name: clusterversion-make-unmanaged
+          ports: []
+          stdin: false
+          tty: false
+          volumeMounts:
+            - mountPath: /export
+              name: export
+          workingDir: /export
+      imagePullSecrets: []
+      initContainers: []
+      restartPolicy: OnFailure
+      serviceAccountName: clusterversion-make-unmanaged
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - emptyDir: {}
+          name: export

--- a/tests/upgrade-controller.yml
+++ b/tests/upgrade-controller.yml
@@ -1,0 +1,2 @@
+applications:
+  - openshift-upgrade-controller


### PR DESCRIPTION
If `openshift-upgrade-controller` is installed the component stops managing the `ClusterVersion`. 

Also adds `Prune=false,Delete=false` to the `ClusterVersion` is still managed so we can remove the application in the future.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
